### PR TITLE
Enhance scientific functions 

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/MyPreferences.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/MyPreferences.kt
@@ -40,8 +40,9 @@ class MyPreferences(context: Context) {
 
     var vibrationMode = preferences.getBoolean(KEY_VIBRATION_STATUS, true)
         set(value) = preferences.edit().putBoolean(KEY_VIBRATION_STATUS, value).apply()
-    var scientificMode = preferences.getBoolean(KEY_SCIENTIFIC_MODE_ENABLED_BY_DEFAULT, false)
-        set(value) = preferences.edit().putBoolean(KEY_SCIENTIFIC_MODE_ENABLED_BY_DEFAULT, value).apply()
+    private val currentScientificModeTypes= MyPreferenceMigrator.migrateScientificMode(preferences, KEY_SCIENTIFIC_MODE_ENABLED_BY_DEFAULT)
+    var scientificMode = preferences.getInt(KEY_SCIENTIFIC_MODE_ENABLED_BY_DEFAULT, currentScientificModeTypes)
+        set(value) = preferences.edit().putInt(KEY_SCIENTIFIC_MODE_ENABLED_BY_DEFAULT, value).apply()
     var useRadiansByDefault = preferences.getBoolean(KEY_RADIANS_INSTEAD_OF_DEGREES_BY_DEFAULT, false)
         set(value) = preferences.edit().putBoolean(KEY_RADIANS_INSTEAD_OF_DEGREES_BY_DEFAULT, value).apply()
     private var history = preferences.getString(KEY_HISTORY, null)

--- a/app/src/main/java/com/darkempire78/opencalculator/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/SettingsActivity.kt
@@ -17,6 +17,7 @@ import com.darkempire78.opencalculator.MyPreferences
 import com.darkempire78.opencalculator.R
 import com.darkempire78.opencalculator.Themes
 import com.darkempire78.opencalculator.calculator.parser.NumberingSystem
+import com.darkempire78.opencalculator.util.ScientificMode
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import java.util.Locale
 
@@ -98,6 +99,21 @@ class SettingsActivity : AppCompatActivity() {
                 openDialogNumberingSystemSelector(this.requireContext())
                 true
             }
+
+
+            // Numbering System button  settings_select_scientificMode_system
+            val scientificModeTypesSystemPreference =
+                findPreference<Preference>("darkempire78.opencalculator.SCIENTIFIC_MODE_ENABLED_BY_DEFAULT")
+
+            val storedType = MyPreferences(requireContext()).scientificMode
+           val scientificModeType = ScientificMode.getScientificModeType(storedType)
+            val typeDescription=ScientificMode.getScientificModeTypeDescription(requireContext(),scientificModeType)
+            scientificModeTypesSystemPreference?.summary = typeDescription
+            scientificModeTypesSystemPreference?.setOnPreferenceClickListener {
+                openDialogScientificModeSelector(this.requireContext())
+                true
+            }
+
         }
 
         private fun openDialogNumberingSystemSelector(context: Context) {
@@ -156,6 +172,45 @@ class SettingsActivity : AppCompatActivity() {
                     println(e)
                 }
             }
+        }
+        private fun openDialogScientificModeSelector(context: Context) {
+
+            val preferences = MyPreferences(context)
+
+            val builder = MaterialAlertDialogBuilder(context)
+            builder.background = ContextCompat.getDrawable(context, R.drawable.rounded)
+
+            val scientificMode = hashMapOf(
+                0 to context.getString(R.string.settings_general_scientific_mode_deactivate_desc),
+                1 to context.getString(R.string.settings_general_scientific_mode_desc),
+                2 to context.getString(R.string.settings_general_scientific_mode_hide_desc)
+            )
+
+            val checkedItem = preferences.scientificMode
+
+            builder.setSingleChoiceItems(
+                scientificMode.values.toTypedArray(),
+                checkedItem
+            ) { dialog, which ->
+                when (which) {
+                    0 -> {
+                        preferences.scientificMode = 0
+                    }
+
+                    1 -> {
+                        preferences.scientificMode = 1
+                    }
+
+                    2-> {
+                        preferences.scientificMode = 2
+                    }
+
+                }
+                dialog.dismiss()
+                reloadActivity(requireContext())
+            }
+            val dialog = builder.create()
+            dialog.show()
         }
     }
 }

--- a/app/src/main/java/com/darkempire78/opencalculator/util/MyPreferenceMigrator.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/util/MyPreferenceMigrator.kt
@@ -1,0 +1,102 @@
+import android.content.SharedPreferences
+import com.darkempire78.opencalculator.util.ScientificModeTypes
+
+/**
+ * Handles migration of SharedPreferences values between different data types.
+ * Primarily used for converting boolean flags to enum ordinal representations.
+ */
+object MyPreferenceMigrator {
+
+
+    /**
+     * Migrates a boolean preference value to its corresponding enum ordinal representation.
+     *
+     * @param sharedPreferences The SharedPreferences instance containing the value to migrate
+     * @param key The preference key to migrate
+     * @return The migrated ordinal value according to these rules:
+     *         - true → ScientificModeTypes.ACTIVE.ordinal (1)
+     *         - false → ScientificModeTypes.NOT_ACTIVE.ordinal (0)
+     *         - Invalid/unknown types → ScientificModeTypes.OFF.ordinal (2)
+     * @throws IllegalArgumentException if sharedPreferences is null
+     */
+    fun migrateScientificMode(sharedPreferences: SharedPreferences, key: String): Int {
+
+        return when (val value = sharedPreferences.all[key]) {
+            // Boolean case - convert to corresponding ordinal
+            is Boolean -> {
+                val modeOrdinal = when {
+                    value -> ScientificModeTypes.ACTIVE.ordinal
+                    else -> ScientificModeTypes.NOT_ACTIVE.ordinal
+                }
+                saveMigratedValue(sharedPreferences, key, modeOrdinal)
+            }
+
+            // Already migrated case (stored as Int)
+            is Int -> {
+                if (value in ScientificModeTypes.entries.toTypedArray().indices) {
+                    value // Return existing valid ordinal
+                } else {
+                    resetToDefault(sharedPreferences, key)
+                }
+            }
+            // All other cases reset to OFF
+            else -> resetToDefault(sharedPreferences, key)
+        }
+    }
+
+    /**
+     * Safely saves a migrated value to SharedPreferences.
+     *
+     * @param sharedPreferences The SharedPreferences instance to modify
+     * @param key The preference key to update
+     * @param value The ordinal value to save
+     * @return The saved ordinal value
+     * @throws IllegalArgumentException if value is not a valid ordinal
+     */
+    private fun saveMigratedValue(
+        sharedPreferences: SharedPreferences,
+        key: String,
+        value: Int
+    ): Int {
+        require(value in ScientificModeTypes.entries.toTypedArray().indices) {
+            "Invalid ordinal value $value for ScientificModeTypes"
+        }
+
+        sharedPreferences.edit()
+            .remove(key) // Remove old value first
+            .putInt(key, value)
+            .apply()
+        return value
+    }
+
+    /**
+     * Resets a preference to the default OFF state.
+     *
+     * @param sharedPreferences The SharedPreferences instance to modify
+     * @param key The preference key to reset
+     * @return The default ordinal value (ScientificModeTypes.OFF.ordinal)
+     */
+    private fun resetToDefault(sharedPreferences: SharedPreferences, key: String): Int {
+        return saveMigratedValue(
+            sharedPreferences,
+            key,
+            ScientificModeTypes.OFF.ordinal
+        )
+    }
+
+    /**
+     * Helper function to safely retrieve the current scientific mode.
+     *
+     * @param sharedPreferences The SharedPreferences instance to read from
+     * @param key The preference key to read
+     * @return The current ScientificModeTypes enum value
+     */
+    fun getCurrentMode(sharedPreferences: SharedPreferences, key: String): ScientificModeTypes {
+        return try {
+            val ordinal = sharedPreferences.getInt(key, ScientificModeTypes.OFF.ordinal)
+            ScientificModeTypes.entries.getOrNull(ordinal) ?: ScientificModeTypes.OFF
+        } catch (e: Exception) {
+            ScientificModeTypes.OFF
+        }
+    }
+}

--- a/app/src/main/java/com/darkempire78/opencalculator/util/ScientificMode.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/util/ScientificMode.kt
@@ -1,0 +1,29 @@
+package com.darkempire78.opencalculator.util
+
+import android.content.Context
+
+object ScientificMode {
+    fun getScientificModeTypeDescription(
+        context: Context,
+        scientificModeTypes: ScientificModeTypes
+    ): String {
+        return when (scientificModeTypes) {
+            ScientificModeTypes.OFF -> context.getString(com.darkempire78.opencalculator.R.string.settings_general_scientific_mode_hide_desc)
+            ScientificModeTypes.NOT_ACTIVE -> context.getString(com.darkempire78.opencalculator.R.string.settings_general_scientific_mode_deactivate_desc)
+            ScientificModeTypes.ACTIVE -> context.getString(com.darkempire78.opencalculator.R.string.settings_general_scientific_mode_desc)
+        }
+    }
+
+    fun getScientificModeType(type:Int):ScientificModeTypes{
+        return when (type) {
+            ScientificModeTypes.NOT_ACTIVE.ordinal -> ScientificModeTypes.NOT_ACTIVE
+            ScientificModeTypes.ACTIVE.ordinal -> ScientificModeTypes.ACTIVE
+            else -> ScientificModeTypes.OFF
+        }
+    }
+}
+enum class ScientificModeTypes{
+    NOT_ACTIVE, //0
+    ACTIVE,//1
+    OFF //2
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -137,6 +137,7 @@
                 app:layout_constraintTop_toTopOf="parent">
 
                 <TableRow
+                    android:id="@+id/scientistModeRow1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="1dp"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -23,6 +23,8 @@
     <string name="settings_general_radians_desc">استخدام الراديان بدلا من الدرجات</string>
     <string name="settings_general_scientific_mode">الوضع العلمي</string>
     <string name="settings_general_scientific_mode_desc">تفعيل الوضع العلمي تلقائيا</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">إلغاء تنشيط الوضع العلمي</string>
+    <string name="settings_general_scientific_mode_hide_desc">إخفاء الوضع العلمي</string>
     <string name="settings_general_split_parenthesis_button">فصل زر الاقواس ليصبح زرين</string>
     <string name="settings_general_split_parenthesis_button_desc">ازالة زر المسح \"AC\" ليتم فصل زر الاقواس الى زرين</string>
     <string name="settings_history_size">النتائج المحفوظة في السجل</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -31,6 +31,8 @@
     <string name="settings_general_theme">Тэма</string>
     <string name="menu_clear_history">Ачысціць гісторыю</string>
     <string name="settings_general_scientific_mode_desc">Выкарыстоўваць інжынерны рэжым па змаўчанні</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Дэактываваць навуковы рэжым</string>
+    <string name="settings_general_scientific_mode_hide_desc">Схаваць навуковы рэжым</string>
     <string name="settings_advanced_prevent_sleep_desc">Не дазваляйце тэлефону пераходзіць у рэжым сну, калі праграма працуе на пярэднім плане</string>
     <string name="settings_general_scientific_mode">Інжынерны рэжым</string>
     <string name="settings_general_vibration_desc">Выдаваць вібрацыю пры націску кнопкі</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -36,6 +36,8 @@
     <string name="settings_general_vibration">Vibracije</string>
     <string name="settings_general_radians_desc">Podrazumevano koristi radijane umjesto stupnjeva</string>
     <string name="settings_general_scientific_mode_desc">Podrazumevano aktiviraj napredni režim</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Deaktiviraj znanstveni način</string>
+    <string name="settings_general_scientific_mode_hide_desc">Skrij znanstveni način</string>
     <string name="settings_formatting_precision">Broj decimalnih mjesta</string>
     <string name="settings_general_language">Jezik</string>
     <string name="about_other_privacy_policy">Politika privatnosti</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -29,6 +29,8 @@
     <string name="settings_general_radians">Radians</string>
     <string name="settings_general_radians_desc">Usa radians en lloc de graus per defecte</string>
     <string name="settings_general_scientific_mode_desc">Activa el mode científic per defecte</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Desactiva el mode científic</string>
+    <string name="settings_general_scientific_mode_hide_desc">Amaga el mode científic</string>
     <string name="settings_formatting_scientific_notation">Número en notació científica</string>
     <string name="settings_formatting_scientific_notation_desc">Converteix tots els resultats en notació científica</string>
     <string name="settings_general_split_parenthesis_button">Divideix el botó dels parèntesis en dos botons</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -20,6 +20,8 @@
     <string name="settings_advanced_prevent_sleep">Udržovat zařízení vzhůru</string>
     <string name="settings_category_advanced">POKROČILÉ</string>
     <string name="settings_general_scientific_mode_desc">Používat vědecký režim jako výchozí</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Deaktivovat vědecký režim</string>
+    <string name="settings_general_scientific_mode_hide_desc">Skrýt vědecký režim</string>
     <string name="settings_general_radians">Radiány</string>
     <string name="settings_general_radians_desc">Používat radiány místo stupňů</string>
     <string name="about_category_help">POMOZTE NÁM</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -24,6 +24,8 @@
     <string name="settings_advanced_prevent_sleep">Bildschirm ausschalten verhindern</string>
     <string name="settings_category_advanced">ERWEITERT</string>
     <string name="settings_general_scientific_mode_desc">Wissenschaftlichen Modus standardmäßig aktivieren</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Wissenschaftlichen Modus deaktivieren</string>
+    <string name="settings_general_scientific_mode_hide_desc">Wissenschaftlichen Modus ausblenden</string>
     <string name="settings_general_scientific_mode">Wissenschaftlicher Modus</string>
     <string name="settings_general_radians">Radiant</string>
     <string name="settings_general_radians_desc">Radiant (RAD) statt Grad (DEG) standardmäßig verwenden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -36,6 +36,8 @@
     <string name="settings_formatting_precision">Cantidad de decimales</string>
     <string name="settings_history_size">Resultados guardados en el historial</string>
     <string name="settings_general_scientific_mode_desc">Activar el modo científico por defecto</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Desactivar el modo científico</string>
+    <string name="settings_general_scientific_mode_hide_desc">Ocultar modo científico</string>
     <string name="about_help_donate">Donar</string>
     <string name="about_help_rate">Valora esta aplicación</string>
     <string name="settings_general_language">Idioma</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -25,6 +25,8 @@
     <string name="settings_general_radians_desc">Vaikimisi kasuta kraadide asemel radiaane</string>
     <string name="settings_general_scientific_mode">Teadusarvutus</string>
     <string name="settings_general_scientific_mode_desc">Vaikimisi lülita sisse teadusarvutuse vaade</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Teadusrežiimi deaktiveerimine</string>
+    <string name="settings_general_scientific_mode_hide_desc">Peida teadusrežiim</string>
     <string name="settings_general_split_parenthesis_button_desc">Eemalda „AC“ nupp ja jaga ümarsulgude nupp kaheks nupuks</string>
     <string name="settings_general_add_modulo">Lisa mooduli nupp</string>
     <string name="settings_formatting_precision">Komakohtade arv</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -24,6 +24,8 @@
     <string name="settings_advanced_prevent_sleep">Empêcher le téléphone de se mettre en veille</string>
     <string name="settings_category_advanced">AVANCÉ</string>
     <string name="settings_general_scientific_mode_desc">Activer le mode scientifique par défaut</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Désactiver le mode scientifique</string>
+    <string name="settings_general_scientific_mode_hide_desc">Masquer le mode scientifique</string>
     <string name="settings_general_scientific_mode">Mode scientifique</string>
     <string name="settings_general_radians">Radians</string>
     <string name="settings_general_radians_desc">Utiliser les radians à la place des degrés par défaut</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -51,6 +51,8 @@
     <string name="settings_general_radians_desc">Bain úsáid as radians in ionad céimeanna de réir réamhshocraithe</string>
     <string name="settings_general_scientific_mode">Modh eolaíoch</string>
     <string name="settings_general_scientific_mode_desc">Gníomhachtaigh mód eolaíoch de réir réamhshocraithe</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Díghníomhachtaigh an mód eolaíoch</string>
+    <string name="settings_general_scientific_mode_hide_desc">Folaigh modh eolaíoch</string>
     <string name="settings_general_split_parenthesis_button">Roinn an cnaipe lúibíní ina dhá chnaipe</string>
     <string name="settings_general_split_parenthesis_button_desc">Bain an cnaipe \"AC\" chun an cnaipe lúibíní a roinnt ina dhá chnaipe</string>
     <string name="settings_general_add_modulo">Cuir cnaipe modulo leis</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -35,6 +35,8 @@
     <string name="value_too_large">मान बहुत बड़ा है</string>
     <string name="settings_general_vibration">कंपन</string>
     <string name="settings_general_scientific_mode_desc">तयशुदा रूप से वैज्ञानिक मोड सक्रिय करें</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">वैज्ञानिक मोड निष्क्रिय करें</string>
+    <string name="settings_general_scientific_mode_hide_desc">वैज्ञानिक मोड छिपाएँ</string>
     <string name="settings_general_split_parenthesis_button">कोष्ठक बटन को दो बटनों में विभाजित करें</string>
     <string name="settings_formatting_scientific_notation">वैज्ञानिक संकेतन में संख्या</string>
     <string name="settings_formatting_scientific_notation_desc">सभी परिणामों को वैज्ञानिक संकेतन में परिवर्तित करें</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -36,6 +36,8 @@
     <string name="settings_category_general">Opće</string>
     <string name="settings_advanced_prevent_sleep_desc">Spriječi isključivanje ekrana dok se aplikacija nalazi u prvom planu</string>
     <string name="settings_general_scientific_mode_desc">Standardno aktiviraj znanstveni način rada</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Deaktiviraj znanstveni način rada</string>
+    <string name="settings_general_scientific_mode_hide_desc">Sakrij znanstveni način rada</string>
     <string name="settings_general_radians_desc">Koristi radijane umjesto stupnjeva prema zadanim postavkama</string>
     <string name="about_other_version">Verzija</string>
     <string name="about_easter_egg">Hvala što koristite OpenCalc ❤️</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -24,6 +24,8 @@
     <string name="syntax_error">Szintaxishiba</string>
     <string name="theme_system">Rendszer</string>
     <string name="settings_general_scientific_mode_desc">Tudományos mód használata alapértelmezés szerint</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Tudományos mód kikapcsolása</string>
+    <string name="settings_general_scientific_mode_hide_desc">Tudományos mód elrejtése</string>
     <string name="about_easter_egg">Köszönjük, hogy az OpenCalc-ot használja ❤️</string>
     <string name="menu_about">Névjegy</string>
     <string name="infinity">Végtelen</string>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -21,6 +21,8 @@
     <string name="syntax_error">Error de syntaxe</string>
     <string name="theme_system">Systema</string>
     <string name="settings_general_scientific_mode_desc">Activar modo scientific per predefinition</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Desactivar el modo científico</string>
+    <string name="settings_general_scientific_mode_hide_desc">Ocultar modo científico</string>
     <string name="about_easter_egg">Gratias per usar OpenCalc ❤️</string>
     <string name="about_category_info">INFORMATION DEL APPLICATION</string>
     <string name="menu_about">A proposito de</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -22,6 +22,8 @@
     <string name="settings_general_language">Bahasa</string>
     <string name="settings_general_vibration">Vibrasi</string>
     <string name="settings_general_scientific_mode_desc">Secara bawaan, gunakan mode ilmiah</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Nonaktifkan mode ilmiah</string>
+    <string name="settings_general_scientific_mode_hide_desc">Sembunyikan mode ilmiah</string>
     <string name="settings_category_general">UMUM</string>
     <string name="settings_general_add_modulo">Tambahkan tombol modulo</string>
     <string name="settings_general_vibration_desc">Bergetar ketika tombol ditekan</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,7 +96,7 @@
     <string name="settings_general_radians_desc">Use radians instead of degrees by default</string>
 
     <string name="settings_general_scientific_mode">Scientific mode</string>
-    <string name="settings_general_scientific_mode_desc">Activate scientific mode by default</string>
+    <string name="settings_general_scientific_mode_desc">Activate scientific mode</string>
 
     <string name="settings_general_split_parenthesis_button">Split the parentheses button into two buttons</string>
     <string name="settings_general_split_parenthesis_button_desc">Remove the \"AC\" button to split the parentheses button into two buttons</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,8 @@
 
     <string name="settings_general_scientific_mode">Scientific mode</string>
     <string name="settings_general_scientific_mode_desc">Activate scientific mode</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">DeActivate scientific mode</string>
+    <string name="settings_general_scientific_mode_hide_desc">Hide scientific mode</string>
 
     <string name="settings_general_split_parenthesis_button">Split the parentheses button into two buttons</string>
     <string name="settings_general_split_parenthesis_button_desc">Remove the \"AC\" button to split the parentheses button into two buttons</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -54,15 +54,15 @@
             app:defaultValue="false"
             app:widgetLayout="@drawable/material_switch" />
 
-        <SwitchPreferenceCompat
+        <Preference
+            android:id="@+id/settings_select_scientificMode_system"
             app:key="darkempire78.opencalculator.SCIENTIFIC_MODE_ENABLED_BY_DEFAULT"
+            app:selectable="true"
+            app:enabled="true"
             app:title="@string/settings_general_scientific_mode"
             app:summary="@string/settings_general_scientific_mode_desc"
-            app:useSimpleSummaryProvider="true"
-            app:icon="@drawable/science"
-            app:singleLineTitle="false"
-            app:defaultValue="false"
-            app:widgetLayout="@drawable/material_switch" />
+            app:icon="@drawable/science" />
+
 
         <SwitchPreferenceCompat
             app:key="darkempire78.opencalculator.SPLIT_PARENTHESIS_BUTTON"


### PR DESCRIPTION
Add "Hide Scientific Mode" Option
Problem Statement
"Users requested the ability to hide the scientific mode bar entirely since some never use it. Currently, the app only allows toggling between ACTIVE and NOT_ACTIVE states, but the UI elements remain visible."

🚀 Solution
✅ Introduced a third state (OFF) in ScientificModeTypes to represent hidden mode.
✅ Added a new string resource (settings_general_scientific_mode_hide_desc).
✅ Updated logic to:

Hide the scientific bar when OFF is selected.

Preserve existing ACTIVE/NOT_ACTIVE toggle functionality.

🔧 Technical Changes
1. Enum Update
kotlin
enum class ScientificModeTypes {
    NOT_ACTIVE,  // 👉 Deactivated but visible
    ACTIVE,      // 👉 Activated and visible
    HIDE          // 👉 Hidden entirely
}
📌 Notes
🔹 Fixes #572
🔹 Follows Android’s Settings UX best practices
🔹 Strings are clear and user-friendly

📸 Screenshots 

<div style="display: flex; gap: 10px; margin-bottom: 15px;">
  <img src="https://github.com/user-attachments/assets/68f92165-a443-4251-b401-b497dc4340fe" alt="Image 1" style="width: 49%; height: "100";"/>
  <img src="https://github.com/user-attachments/assets/32495aff-c18c-4727-84d2-b1ecde35038f" alt="Image 2" style="width: 49%; height: "100";"/>
</div>
<div style="display: flex; gap: 10px;">
  <img src="https://github.com/user-attachments/assets/2e073465-4b6c-4920-ab2c-dd72e978eb1b" alt="Image 3" style="width: 49%; height: "100";"/>
  <img src="https://github.com/user-attachments/assets/32b3f16e-f5c9-41df-816a-43020b0c8e24" alt="Image 4" style="width: 49%; height: "100";"/>
</div>
