### PR TITLE
Enhance scientific functions

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/MyPreferences.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/MyPreferences.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate.*
 import androidx.preference.PreferenceManager
 import com.darkempire78.opencalculator.history.History
+import com.darkempire78.opencalculator.util.ScientificModeTypes
 import com.google.gson.Gson
 
 class MyPreferences(context: Context) {
@@ -40,8 +41,8 @@ class MyPreferences(context: Context) {
 
     var vibrationMode = preferences.getBoolean(KEY_VIBRATION_STATUS, true)
         set(value) = preferences.edit().putBoolean(KEY_VIBRATION_STATUS, value).apply()
-    var scientificMode = preferences.getBoolean(KEY_SCIENTIFIC_MODE_ENABLED_BY_DEFAULT, false)
-        set(value) = preferences.edit().putBoolean(KEY_SCIENTIFIC_MODE_ENABLED_BY_DEFAULT, value).apply()
+    var scientificMode = preferences.getInt(KEY_SCIENTIFIC_MODE_ENABLED_BY_DEFAULT, ScientificModeTypes.NOT_ACTIVE.ordinal)
+        set(value) = preferences.edit().putInt(KEY_SCIENTIFIC_MODE_ENABLED_BY_DEFAULT, value).apply()
     var useRadiansByDefault = preferences.getBoolean(KEY_RADIANS_INSTEAD_OF_DEGREES_BY_DEFAULT, false)
         set(value) = preferences.edit().putBoolean(KEY_RADIANS_INSTEAD_OF_DEGREES_BY_DEFAULT, value).apply()
     private var history = preferences.getString(KEY_HISTORY, null)

--- a/app/src/main/java/com/darkempire78/opencalculator/MyPreferences.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/MyPreferences.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate.*
 import androidx.preference.PreferenceManager
 import com.darkempire78.opencalculator.history.History
-import com.darkempire78.opencalculator.util.ScientificModeTypes
 import com.google.gson.Gson
 
 class MyPreferences(context: Context) {
@@ -41,7 +40,8 @@ class MyPreferences(context: Context) {
 
     var vibrationMode = preferences.getBoolean(KEY_VIBRATION_STATUS, true)
         set(value) = preferences.edit().putBoolean(KEY_VIBRATION_STATUS, value).apply()
-    var scientificMode = preferences.getInt(KEY_SCIENTIFIC_MODE_ENABLED_BY_DEFAULT, ScientificModeTypes.NOT_ACTIVE.ordinal)
+    private val currentScientificModeTypes= MyPreferenceMigrator.migrateScientificMode(preferences, KEY_SCIENTIFIC_MODE_ENABLED_BY_DEFAULT)
+    var scientificMode = preferences.getInt(KEY_SCIENTIFIC_MODE_ENABLED_BY_DEFAULT, currentScientificModeTypes)
         set(value) = preferences.edit().putInt(KEY_SCIENTIFIC_MODE_ENABLED_BY_DEFAULT, value).apply()
     var useRadiansByDefault = preferences.getBoolean(KEY_RADIANS_INSTEAD_OF_DEGREES_BY_DEFAULT, false)
         set(value) = preferences.edit().putBoolean(KEY_RADIANS_INSTEAD_OF_DEGREES_BY_DEFAULT, value).apply()

--- a/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
@@ -544,40 +544,6 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun manageScientificMode(scientificModeTypes: ScientificModeTypes) {
-        when (scientificModeTypes) {
-            ScientificModeTypes.OFF -> hideScientificMode()
-            ScientificModeTypes.ACTIVE -> enableOrDisableScientistMode(true)
-            ScientificModeTypes.NOT_ACTIVE -> enableOrDisableScientistMode(false)
-        }
-    }
-
-
-    private fun enableOrDisableScientistMode(isEnabled: Boolean) {
-        val imageId = if (isEnabled) R.drawable.ic_baseline_keyboard_arrow_up_24 else R.drawable.ic_baseline_keyboard_arrow_down_24
-        binding.scientistModeRow1?.isVisible = true
-        binding.scientistModeRow2.isVisible = isEnabled
-        binding.scientistModeRow3.isVisible = isEnabled
-        binding.degreeTextView.visibility = View.VISIBLE
-        binding.scientistModeSwitchButton?.setImageResource(imageId)
-
-        if (isDegreeModeActivated) {
-            binding.degreeButton.text = getString(R.string.radian)
-            binding.degreeTextView.text = getString(R.string.degree)
-        } else {
-            binding.degreeButton.text = getString(R.string.degree)
-            binding.degreeTextView.text = getString(R.string.radian)
-        }
-
-    }
-
-    private fun hideScientificMode() {
-        binding.scientistModeRow1?.visibility = View.GONE
-        binding.scientistModeRow2.visibility = View.GONE
-        binding.scientistModeRow3.visibility = View.GONE
-        binding.degreeTextView.visibility = View.GONE
-    }
-
     // Switch between degree and radian mode
     private fun toggleDegreeMode() {
         isDegreeModeActivated = !isDegreeModeActivated
@@ -1365,5 +1331,39 @@ class MainActivity : AppCompatActivity() {
             binding.noHistoryText.visibility = View.GONE
             binding.historyRecylcleView.visibility = View.VISIBLE
         }
+    }
+
+    private fun manageScientificMode(scientificModeTypes: ScientificModeTypes) {
+        when (scientificModeTypes) {
+            ScientificModeTypes.OFF -> hideScientificMode()
+            ScientificModeTypes.ACTIVE -> enableOrDisableScientistMode(true)
+            ScientificModeTypes.NOT_ACTIVE -> enableOrDisableScientistMode(false)
+        }
+    }
+
+
+    private fun enableOrDisableScientistMode(isEnabled: Boolean) {
+        val imageId = if (isEnabled) R.drawable.ic_baseline_keyboard_arrow_up_24 else R.drawable.ic_baseline_keyboard_arrow_down_24
+        binding.scientistModeRow1?.isVisible = true
+        binding.scientistModeRow2.isVisible = isEnabled
+        binding.scientistModeRow3.isVisible = isEnabled
+        binding.degreeTextView.visibility = View.VISIBLE
+        binding.scientistModeSwitchButton?.setImageResource(imageId)
+
+        if (isDegreeModeActivated) {
+            binding.degreeButton.text = getString(R.string.radian)
+            binding.degreeTextView.text = getString(R.string.degree)
+        } else {
+            binding.degreeButton.text = getString(R.string.degree)
+            binding.degreeTextView.text = getString(R.string.radian)
+        }
+
+    }
+
+    private fun hideScientificMode() {
+        binding.scientistModeRow1?.visibility = View.GONE
+        binding.scientistModeRow2.visibility = View.GONE
+        binding.scientistModeRow3.visibility = View.GONE
+        binding.degreeTextView.visibility = View.GONE
     }
 }

--- a/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
@@ -23,6 +23,7 @@ import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.PopupMenu
 import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -275,7 +276,8 @@ class MainActivity : AppCompatActivity() {
 
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 updateResultDisplay()
-                textSizeAdjuster.adjustTextSize(binding.input,
+                textSizeAdjuster.adjustTextSize(
+                    binding.input,
                     TextSizeAdjuster.AdjustableTextType.Input
                 )
             }
@@ -285,7 +287,7 @@ class MainActivity : AppCompatActivity() {
             }
         })
 
-        binding.resultDisplay.addTextChangedListener(object: TextWatcher {
+        binding.resultDisplay.addTextChangedListener(object : TextWatcher {
             private var beforeTextLength = 0
 
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
@@ -293,7 +295,8 @@ class MainActivity : AppCompatActivity() {
             }
 
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                textSizeAdjuster.adjustTextSize(binding.resultDisplay,
+                textSizeAdjuster.adjustTextSize(
+                    binding.resultDisplay,
                     TextSizeAdjuster.AdjustableTextType.Output
                 )
             }
@@ -325,10 +328,12 @@ class MainActivity : AppCompatActivity() {
                     updateDisplay(view, "00")
                     true
                 }
+
                 R.id.option_triple_zero -> {
                     updateDisplay(view, "000")
                     true
                 }
+
                 else -> false
             }
         }
@@ -346,6 +351,7 @@ class MainActivity : AppCompatActivity() {
             ): Boolean {
                 return false
             }
+
             override fun isItemViewSwipeEnabled(): Boolean {
                 return MyPreferences(this@MainActivity).deleteHistoryOnSwipe
             }
@@ -470,13 +476,23 @@ class MainActivity : AppCompatActivity() {
             val cursorPosition = binding.input.selectionStart
             val leftValue = formerValue.subSequence(0, cursorPosition).toString()
             val leftValueFormatted =
-                NumberFormatter.format(leftValue, decimalSeparatorSymbol, groupingSeparatorSymbol, numberingSystem)
+                NumberFormatter.format(
+                    leftValue,
+                    decimalSeparatorSymbol,
+                    groupingSeparatorSymbol,
+                    numberingSystem
+                )
             val rightValue = formerValue.subSequence(cursorPosition, formerValue.length).toString()
 
             val newValue = leftValue + value + rightValue
 
             val newValueFormatted =
-                NumberFormatter.format(newValue, decimalSeparatorSymbol, groupingSeparatorSymbol, numberingSystem)
+                NumberFormatter.format(
+                    newValue,
+                    decimalSeparatorSymbol,
+                    groupingSeparatorSymbol,
+                    numberingSystem
+                )
 
             withContext(Dispatchers.Main) {
                 // Update Display
@@ -489,7 +505,8 @@ class MainActivity : AppCompatActivity() {
                 } else {
                     val desiredCursorPosition = leftValueFormatted.length + value.length
                     // Limit the cursor position to the length of the input
-                    val safeCursorPosition = desiredCursorPosition.coerceAtMost(binding.input.text.length)
+                    val safeCursorPosition =
+                        desiredCursorPosition.coerceAtMost(binding.input.text.length)
                     binding.input.setSelection(safeCursorPosition)
                 }
             }
@@ -530,8 +547,7 @@ class MainActivity : AppCompatActivity() {
             if (isDegreeModeActivated) {
                 binding.degreeButton.text = getString(R.string.radian)
                 binding.degreeTextView.text = getString(R.string.degree)
-            }
-            else {
+            } else {
                 binding.degreeButton.text = getString(R.string.degree)
                 binding.degreeTextView.text = getString(R.string.radian)
             }
@@ -553,31 +569,27 @@ class MainActivity : AppCompatActivity() {
 
 
     private fun enableOrDisableScientistMode(isEnabled: Boolean) {
-        if (isEnabled) {
-            binding.scientistModeRow2.visibility = View.VISIBLE
-            binding.scientistModeRow3.visibility = View.VISIBLE
-            binding.scientistModeSwitchButton?.setImageResource(R.drawable.ic_baseline_keyboard_arrow_up_24)
-            binding.degreeTextView.visibility = View.VISIBLE
-            if (isDegreeModeActivated) {
-                binding.degreeButton.text = getString(R.string.radian)
-                binding.degreeTextView.text = getString(R.string.degree)
-            } else {
-                binding.degreeButton.text = getString(R.string.degree)
-                binding.degreeTextView.text = getString(R.string.radian)
-            }
+        val imageId = if (isEnabled) R.drawable.ic_baseline_keyboard_arrow_up_24 else R.drawable.ic_baseline_keyboard_arrow_down_24
+        binding.scientistModeRow1?.isVisible = true
+        binding.scientistModeRow2.isVisible = isEnabled
+        binding.scientistModeRow3.isVisible = isEnabled
+        binding.degreeTextView.visibility = View.VISIBLE
+        binding.scientistModeSwitchButton?.setImageResource(imageId)
+
+        if (isDegreeModeActivated) {
+            binding.degreeButton.text = getString(R.string.radian)
+            binding.degreeTextView.text = getString(R.string.degree)
         } else {
-            binding.scientistModeRow2.visibility = View.GONE
-            binding.scientistModeRow3.visibility = View.GONE
-            binding.scientistModeSwitchButton?.setImageResource(R.drawable.ic_baseline_keyboard_arrow_down_24)
-            binding.degreeTextView.visibility = View.GONE
+            binding.degreeButton.text = getString(R.string.degree)
+            binding.degreeTextView.text = getString(R.string.radian)
         }
+
     }
 
     private fun hideScientificMode() {
         binding.scientistModeRow1?.visibility = View.GONE
         binding.scientistModeRow2.visibility = View.GONE
         binding.scientistModeRow3.visibility = View.GONE
-        binding.scientistModeSwitchButton?.visibility = View.GONE
         binding.degreeTextView.visibility = View.GONE
     }
 
@@ -587,8 +599,7 @@ class MainActivity : AppCompatActivity() {
         if (isDegreeModeActivated) {
             binding.degreeButton.text = getString(R.string.radian)
             binding.degreeTextView.text = getString(R.string.degree)
-        }
-        else {
+        } else {
             binding.degreeButton.text = getString(R.string.degree)
             binding.degreeTextView.text = getString(R.string.radian)
         }
@@ -675,14 +686,19 @@ class MainActivity : AppCompatActivity() {
                             if (isStillTheSameCalculation_autoSaveCalculationWithoutEqualOption) {
                                 // If it's the same calculation as the previous one
                                 // Get previous calculation and update it
-                                val previousHistoryElement = MyPreferences(this@MainActivity).getHistoryElementById(
-                                    lastHistoryElementId
-                                )
+                                val previousHistoryElement =
+                                    MyPreferences(this@MainActivity).getHistoryElementById(
+                                        lastHistoryElementId
+                                    )
                                 if (previousHistoryElement != null) {
                                     previousHistoryElement.calculation = calculation
                                     previousHistoryElement.result = formattedResult
-                                    previousHistoryElement.time = System.currentTimeMillis().toString()
-                                    MyPreferences(this@MainActivity).updateHistoryElementById(lastHistoryElementId, previousHistoryElement)
+                                    previousHistoryElement.time =
+                                        System.currentTimeMillis().toString()
+                                    MyPreferences(this@MainActivity).updateHistoryElementById(
+                                        lastHistoryElementId,
+                                        previousHistoryElement
+                                    )
                                     withContext(Dispatchers.Main) {
                                         historyAdapter.updateHistoryElement(previousHistoryElement)
                                     }
@@ -705,7 +721,8 @@ class MainActivity : AppCompatActivity() {
                                 )
 
                                 lastHistoryElementId = historyElementId
-                                isStillTheSameCalculation_autoSaveCalculationWithoutEqualOption = true
+                                isStillTheSameCalculation_autoSaveCalculationWithoutEqualOption =
+                                    true
 
                                 MyPreferences(this@MainActivity).saveHistory(history)
 
@@ -716,12 +733,14 @@ class MainActivity : AppCompatActivity() {
                                             calculation = calculation,
                                             result = formattedResult,
                                             time = currentTime,
-                                            id = UUID.randomUUID().toString() // Generate a random id
+                                            id = UUID.randomUUID()
+                                                .toString() // Generate a random id
                                         )
                                     )
 
                                     // Remove former results if > historySize preference
-                                    val historySize = MyPreferences(this@MainActivity).historySize!!.toInt()
+                                    val historySize =
+                                        MyPreferences(this@MainActivity).historySize!!.toInt()
                                     while (historySize != -1 && historyAdapter.itemCount >= historySize && historyAdapter.itemCount > 0) {
                                         historyAdapter.removeFirstHistoryElement()
                                     }
@@ -736,9 +755,10 @@ class MainActivity : AppCompatActivity() {
 
                 } else withContext(Dispatchers.Main) {
                     if (is_infinity && !division_by_0 && !domain_error && !require_real_number) {
-                        if (calculationResult < BigDecimal.ZERO) binding.resultDisplay.text = "-" + getString(
-                            R.string.infinity
-                        )
+                        if (calculationResult < BigDecimal.ZERO) binding.resultDisplay.text =
+                            "-" + getString(
+                                R.string.infinity
+                            )
                         else binding.resultDisplay.text = getString(R.string.value_too_large)
                     } else {
                         withContext(Dispatchers.Main) {
@@ -788,8 +808,10 @@ class MainActivity : AppCompatActivity() {
                 if (previousChar.matches("[+\\-÷×^]".toRegex())) {
                     keyVibration(view)
 
-                    val leftString = binding.input.text.subSequence(0, cursorPosition - 1).toString()
-                    val rightString = binding.input.text.subSequence(cursorPosition, textLength).toString()
+                    val leftString =
+                        binding.input.text.subSequence(0, cursorPosition - 1).toString()
+                    val rightString =
+                        binding.input.text.subSequence(cursorPosition, textLength).toString()
 
                     // Add a parenthesis if there is another symbol before minus
                     if (currentSymbol == "-") {
@@ -815,7 +837,8 @@ class MainActivity : AppCompatActivity() {
                     keyVibration(view)
 
                     val leftString = binding.input.text.subSequence(0, cursorPosition).toString()
-                    val rightString = binding.input.text.subSequence(cursorPosition + 1, textLength).toString()
+                    val rightString =
+                        binding.input.text.subSequence(cursorPosition + 1, textLength).toString()
 
                     if (cursorPosition > 0 && previousChar != "(") {
                         binding.input.setText(leftString + currentSymbol + rightString)
@@ -863,7 +886,8 @@ class MainActivity : AppCompatActivity() {
                 startPosition = cursorPosition
                 while (startPosition > 0 && (binding.input.text[startPosition - 1].isDigit()
                             || binding.input.text[startPosition - 1].toString() == decimalSeparatorSymbol
-                            || binding.input.text[startPosition - 1].toString() == groupingSeparatorSymbol)) {
+                            || binding.input.text[startPosition - 1].toString() == groupingSeparatorSymbol)
+                ) {
                     startPosition -= 1
                 }
             }
@@ -875,9 +899,10 @@ class MainActivity : AppCompatActivity() {
                 while (endPosition < binding.input.text.length
                     && (binding.input.text[endPosition].isDigit()
                             || binding.input.text[endPosition].toString() == decimalSeparatorSymbol
-                            || binding.input.text[endPosition].toString() == groupingSeparatorSymbol)) {
-                        endPosition += 1
-                    }
+                            || binding.input.text[endPosition].toString() == groupingSeparatorSymbol)
+                ) {
+                    endPosition += 1
+                }
             }
             currentNumber = binding.input.text.substring(startPosition, endPosition)
         }
@@ -1107,7 +1132,8 @@ class MainActivity : AppCompatActivity() {
                                 )
 
                                 // Remove former results if > historySize preference
-                                val historySize = MyPreferences(this@MainActivity).historySize!!.toInt()
+                                val historySize =
+                                    MyPreferences(this@MainActivity).historySize!!.toInt()
                                 while (historySize != -1 && historyAdapter.itemCount >= historySize && historyAdapter.itemCount > 0) {
                                     historyAdapter.removeFirstHistoryElement()
                                 }
@@ -1133,9 +1159,10 @@ class MainActivity : AppCompatActivity() {
                             setErrorColor(true)
                             binding.resultDisplay.text = getString(R.string.division_by_0)
                         } else if (is_infinity) {
-                            if (calculationResult < BigDecimal.ZERO) binding.resultDisplay.text = "-" + getString(
-                                R.string.infinity
-                            )
+                            if (calculationResult < BigDecimal.ZERO) binding.resultDisplay.text =
+                                "-" + getString(
+                                    R.string.infinity
+                                )
                             else binding.resultDisplay.text = getString(R.string.value_too_large)
                             //} else if (result.isNaN()) {
                             //    setErrorColor(true)
@@ -1211,7 +1238,18 @@ class MainActivity : AppCompatActivity() {
         if (cursorPosition != 0 && textLength != 0) {
             // Check if it is a function to delete
             val functionsList =
-                listOf("cos⁻¹(", "sin⁻¹(", "tan⁻¹(", "cos(", "sin(", "tan(", "ln(", "log(", "log₂(", "exp(")
+                listOf(
+                    "cos⁻¹(",
+                    "sin⁻¹(",
+                    "tan⁻¹(",
+                    "cos(",
+                    "sin(",
+                    "tan(",
+                    "ln(",
+                    "log(",
+                    "log₂(",
+                    "exp("
+                )
             for (function in functionsList) {
                 val leftPart = binding.input.text.subSequence(0, cursorPosition).toString()
                 if (leftPart.endsWith(function)) {
@@ -1275,7 +1313,12 @@ class MainActivity : AppCompatActivity() {
 
     private fun updateInputDisplay() {
         val expression = binding.input.text.toString()
-        val formatted = NumberFormatter.format(expression, decimalSeparatorSymbol, groupingSeparatorSymbol, numberingSystem)
+        val formatted = NumberFormatter.format(
+            expression,
+            decimalSeparatorSymbol,
+            groupingSeparatorSymbol,
+            numberingSystem
+        )
         val cursorPosition = binding.input.selectionStart
         binding.input.setText(formatted)
         // Set cursor to previous location before resume.
@@ -1366,10 +1409,10 @@ class MainActivity : AppCompatActivity() {
     }
 
     fun checkEmptyHistoryForNoHistoryLabel() {
-        if (historyAdapter.itemCount==0) {
+        if (historyAdapter.itemCount == 0) {
             binding.historyRecylcleView.visibility = View.GONE
             binding.noHistoryText.visibility = View.VISIBLE
-        }else {
+        } else {
             binding.noHistoryText.visibility = View.GONE
             binding.historyRecylcleView.visibility = View.VISIBLE
         }

--- a/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/MainActivity.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
 import android.view.HapticFeedbackConstants
 import android.view.MenuItem
 import android.view.View
@@ -276,8 +277,7 @@ class MainActivity : AppCompatActivity() {
 
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 updateResultDisplay()
-                textSizeAdjuster.adjustTextSize(
-                    binding.input,
+                textSizeAdjuster.adjustTextSize(binding.input,
                     TextSizeAdjuster.AdjustableTextType.Input
                 )
             }
@@ -287,7 +287,7 @@ class MainActivity : AppCompatActivity() {
             }
         })
 
-        binding.resultDisplay.addTextChangedListener(object : TextWatcher {
+        binding.resultDisplay.addTextChangedListener(object: TextWatcher {
             private var beforeTextLength = 0
 
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
@@ -295,8 +295,7 @@ class MainActivity : AppCompatActivity() {
             }
 
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                textSizeAdjuster.adjustTextSize(
-                    binding.resultDisplay,
+                textSizeAdjuster.adjustTextSize(binding.resultDisplay,
                     TextSizeAdjuster.AdjustableTextType.Output
                 )
             }
@@ -328,12 +327,10 @@ class MainActivity : AppCompatActivity() {
                     updateDisplay(view, "00")
                     true
                 }
-
                 R.id.option_triple_zero -> {
                     updateDisplay(view, "000")
                     true
                 }
-
                 else -> false
             }
         }
@@ -351,7 +348,6 @@ class MainActivity : AppCompatActivity() {
             ): Boolean {
                 return false
             }
-
             override fun isItemViewSwipeEnabled(): Boolean {
                 return MyPreferences(this@MainActivity).deleteHistoryOnSwipe
             }
@@ -476,23 +472,13 @@ class MainActivity : AppCompatActivity() {
             val cursorPosition = binding.input.selectionStart
             val leftValue = formerValue.subSequence(0, cursorPosition).toString()
             val leftValueFormatted =
-                NumberFormatter.format(
-                    leftValue,
-                    decimalSeparatorSymbol,
-                    groupingSeparatorSymbol,
-                    numberingSystem
-                )
+                NumberFormatter.format(leftValue, decimalSeparatorSymbol, groupingSeparatorSymbol, numberingSystem)
             val rightValue = formerValue.subSequence(cursorPosition, formerValue.length).toString()
 
             val newValue = leftValue + value + rightValue
 
             val newValueFormatted =
-                NumberFormatter.format(
-                    newValue,
-                    decimalSeparatorSymbol,
-                    groupingSeparatorSymbol,
-                    numberingSystem
-                )
+                NumberFormatter.format(newValue, decimalSeparatorSymbol, groupingSeparatorSymbol, numberingSystem)
 
             withContext(Dispatchers.Main) {
                 // Update Display
@@ -505,8 +491,7 @@ class MainActivity : AppCompatActivity() {
                 } else {
                     val desiredCursorPosition = leftValueFormatted.length + value.length
                     // Limit the cursor position to the length of the input
-                    val safeCursorPosition =
-                        desiredCursorPosition.coerceAtMost(binding.input.text.length)
+                    val safeCursorPosition = desiredCursorPosition.coerceAtMost(binding.input.text.length)
                     binding.input.setSelection(safeCursorPosition)
                 }
             }
@@ -537,7 +522,6 @@ class MainActivity : AppCompatActivity() {
         return newResult
     }
 
-
     private fun enableOrDisableScientistMode() {
         if (binding.scientistModeRow2.visibility != View.VISIBLE) {
             binding.scientistModeRow2.visibility = View.VISIBLE
@@ -547,7 +531,8 @@ class MainActivity : AppCompatActivity() {
             if (isDegreeModeActivated) {
                 binding.degreeButton.text = getString(R.string.radian)
                 binding.degreeTextView.text = getString(R.string.degree)
-            } else {
+            }
+            else {
                 binding.degreeButton.text = getString(R.string.degree)
                 binding.degreeTextView.text = getString(R.string.radian)
             }
@@ -599,7 +584,8 @@ class MainActivity : AppCompatActivity() {
         if (isDegreeModeActivated) {
             binding.degreeButton.text = getString(R.string.radian)
             binding.degreeTextView.text = getString(R.string.degree)
-        } else {
+        }
+        else {
             binding.degreeButton.text = getString(R.string.degree)
             binding.degreeTextView.text = getString(R.string.radian)
         }
@@ -686,19 +672,14 @@ class MainActivity : AppCompatActivity() {
                             if (isStillTheSameCalculation_autoSaveCalculationWithoutEqualOption) {
                                 // If it's the same calculation as the previous one
                                 // Get previous calculation and update it
-                                val previousHistoryElement =
-                                    MyPreferences(this@MainActivity).getHistoryElementById(
-                                        lastHistoryElementId
-                                    )
+                                val previousHistoryElement = MyPreferences(this@MainActivity).getHistoryElementById(
+                                    lastHistoryElementId
+                                )
                                 if (previousHistoryElement != null) {
                                     previousHistoryElement.calculation = calculation
                                     previousHistoryElement.result = formattedResult
-                                    previousHistoryElement.time =
-                                        System.currentTimeMillis().toString()
-                                    MyPreferences(this@MainActivity).updateHistoryElementById(
-                                        lastHistoryElementId,
-                                        previousHistoryElement
-                                    )
+                                    previousHistoryElement.time = System.currentTimeMillis().toString()
+                                    MyPreferences(this@MainActivity).updateHistoryElementById(lastHistoryElementId, previousHistoryElement)
                                     withContext(Dispatchers.Main) {
                                         historyAdapter.updateHistoryElement(previousHistoryElement)
                                     }
@@ -721,8 +702,7 @@ class MainActivity : AppCompatActivity() {
                                 )
 
                                 lastHistoryElementId = historyElementId
-                                isStillTheSameCalculation_autoSaveCalculationWithoutEqualOption =
-                                    true
+                                isStillTheSameCalculation_autoSaveCalculationWithoutEqualOption = true
 
                                 MyPreferences(this@MainActivity).saveHistory(history)
 
@@ -733,14 +713,12 @@ class MainActivity : AppCompatActivity() {
                                             calculation = calculation,
                                             result = formattedResult,
                                             time = currentTime,
-                                            id = UUID.randomUUID()
-                                                .toString() // Generate a random id
+                                            id = UUID.randomUUID().toString() // Generate a random id
                                         )
                                     )
 
                                     // Remove former results if > historySize preference
-                                    val historySize =
-                                        MyPreferences(this@MainActivity).historySize!!.toInt()
+                                    val historySize = MyPreferences(this@MainActivity).historySize!!.toInt()
                                     while (historySize != -1 && historyAdapter.itemCount >= historySize && historyAdapter.itemCount > 0) {
                                         historyAdapter.removeFirstHistoryElement()
                                     }
@@ -755,10 +733,9 @@ class MainActivity : AppCompatActivity() {
 
                 } else withContext(Dispatchers.Main) {
                     if (is_infinity && !division_by_0 && !domain_error && !require_real_number) {
-                        if (calculationResult < BigDecimal.ZERO) binding.resultDisplay.text =
-                            "-" + getString(
-                                R.string.infinity
-                            )
+                        if (calculationResult < BigDecimal.ZERO) binding.resultDisplay.text = "-" + getString(
+                            R.string.infinity
+                        )
                         else binding.resultDisplay.text = getString(R.string.value_too_large)
                     } else {
                         withContext(Dispatchers.Main) {
@@ -808,10 +785,8 @@ class MainActivity : AppCompatActivity() {
                 if (previousChar.matches("[+\\-÷×^]".toRegex())) {
                     keyVibration(view)
 
-                    val leftString =
-                        binding.input.text.subSequence(0, cursorPosition - 1).toString()
-                    val rightString =
-                        binding.input.text.subSequence(cursorPosition, textLength).toString()
+                    val leftString = binding.input.text.subSequence(0, cursorPosition - 1).toString()
+                    val rightString = binding.input.text.subSequence(cursorPosition, textLength).toString()
 
                     // Add a parenthesis if there is another symbol before minus
                     if (currentSymbol == "-") {
@@ -837,8 +812,7 @@ class MainActivity : AppCompatActivity() {
                     keyVibration(view)
 
                     val leftString = binding.input.text.subSequence(0, cursorPosition).toString()
-                    val rightString =
-                        binding.input.text.subSequence(cursorPosition + 1, textLength).toString()
+                    val rightString = binding.input.text.subSequence(cursorPosition + 1, textLength).toString()
 
                     if (cursorPosition > 0 && previousChar != "(") {
                         binding.input.setText(leftString + currentSymbol + rightString)
@@ -886,8 +860,7 @@ class MainActivity : AppCompatActivity() {
                 startPosition = cursorPosition
                 while (startPosition > 0 && (binding.input.text[startPosition - 1].isDigit()
                             || binding.input.text[startPosition - 1].toString() == decimalSeparatorSymbol
-                            || binding.input.text[startPosition - 1].toString() == groupingSeparatorSymbol)
-                ) {
+                            || binding.input.text[startPosition - 1].toString() == groupingSeparatorSymbol)) {
                     startPosition -= 1
                 }
             }
@@ -899,10 +872,9 @@ class MainActivity : AppCompatActivity() {
                 while (endPosition < binding.input.text.length
                     && (binding.input.text[endPosition].isDigit()
                             || binding.input.text[endPosition].toString() == decimalSeparatorSymbol
-                            || binding.input.text[endPosition].toString() == groupingSeparatorSymbol)
-                ) {
-                    endPosition += 1
-                }
+                            || binding.input.text[endPosition].toString() == groupingSeparatorSymbol)) {
+                        endPosition += 1
+                    }
             }
             currentNumber = binding.input.text.substring(startPosition, endPosition)
         }
@@ -1132,8 +1104,7 @@ class MainActivity : AppCompatActivity() {
                                 )
 
                                 // Remove former results if > historySize preference
-                                val historySize =
-                                    MyPreferences(this@MainActivity).historySize!!.toInt()
+                                val historySize = MyPreferences(this@MainActivity).historySize!!.toInt()
                                 while (historySize != -1 && historyAdapter.itemCount >= historySize && historyAdapter.itemCount > 0) {
                                     historyAdapter.removeFirstHistoryElement()
                                 }
@@ -1159,10 +1130,9 @@ class MainActivity : AppCompatActivity() {
                             setErrorColor(true)
                             binding.resultDisplay.text = getString(R.string.division_by_0)
                         } else if (is_infinity) {
-                            if (calculationResult < BigDecimal.ZERO) binding.resultDisplay.text =
-                                "-" + getString(
-                                    R.string.infinity
-                                )
+                            if (calculationResult < BigDecimal.ZERO) binding.resultDisplay.text = "-" + getString(
+                                R.string.infinity
+                            )
                             else binding.resultDisplay.text = getString(R.string.value_too_large)
                             //} else if (result.isNaN()) {
                             //    setErrorColor(true)
@@ -1238,18 +1208,7 @@ class MainActivity : AppCompatActivity() {
         if (cursorPosition != 0 && textLength != 0) {
             // Check if it is a function to delete
             val functionsList =
-                listOf(
-                    "cos⁻¹(",
-                    "sin⁻¹(",
-                    "tan⁻¹(",
-                    "cos(",
-                    "sin(",
-                    "tan(",
-                    "ln(",
-                    "log(",
-                    "log₂(",
-                    "exp("
-                )
+                listOf("cos⁻¹(", "sin⁻¹(", "tan⁻¹(", "cos(", "sin(", "tan(", "ln(", "log(", "log₂(", "exp(")
             for (function in functionsList) {
                 val leftPart = binding.input.text.subSequence(0, cursorPosition).toString()
                 if (leftPart.endsWith(function)) {
@@ -1292,12 +1251,7 @@ class MainActivity : AppCompatActivity() {
             }
 
             val newValueFormatted =
-                NumberFormatter.format(
-                    newValue,
-                    decimalSeparatorSymbol,
-                    groupingSeparatorSymbol,
-                    numberingSystem
-                )
+                NumberFormatter.format(newValue, decimalSeparatorSymbol, groupingSeparatorSymbol, numberingSystem)
             var cursorOffset = newValueFormatted.length - newValue.length - rightSideCommas
             if (cursorOffset < 0) cursorOffset = 0
 
@@ -1313,12 +1267,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun updateInputDisplay() {
         val expression = binding.input.text.toString()
-        val formatted = NumberFormatter.format(
-            expression,
-            decimalSeparatorSymbol,
-            groupingSeparatorSymbol,
-            numberingSystem
-        )
+        val formatted = NumberFormatter.format(expression, decimalSeparatorSymbol, groupingSeparatorSymbol, numberingSystem)
         val cursorPosition = binding.input.selectionStart
         binding.input.setText(formatted)
         // Set cursor to previous location before resume.
@@ -1336,6 +1285,7 @@ class MainActivity : AppCompatActivity() {
             scientificModeType = ScientificMode.getScientificModeType(storedType)
             manageScientificMode(scientificModeType)
         }
+
 
         val fromPrefs = MyPreferences(this).numberingSystem
         numberingSystem = fromPrefs.toNumberingSystem()
@@ -1405,14 +1355,13 @@ class MainActivity : AppCompatActivity() {
 
         // Disable the keyboard on display EditText
         binding.input.showSoftInputOnFocus = false
-
     }
 
     fun checkEmptyHistoryForNoHistoryLabel() {
-        if (historyAdapter.itemCount == 0) {
+        if (historyAdapter.itemCount==0) {
             binding.historyRecylcleView.visibility = View.GONE
             binding.noHistoryText.visibility = View.VISIBLE
-        } else {
+        }else {
             binding.noHistoryText.visibility = View.GONE
             binding.historyRecylcleView.visibility = View.VISIBLE
         }

--- a/app/src/main/java/com/darkempire78/opencalculator/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/SettingsActivity.kt
@@ -150,6 +150,29 @@ class SettingsActivity : AppCompatActivity() {
             dialog.show()
         }
 
+        private fun reloadActivity(context: Context) {
+            (context as Activity).finish()
+            ContextCompat.startActivity(context, context.intent, null)
+        }
+
+        @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+        fun launchChangeAppLanguageIntent() {
+            try {
+                Intent(Settings.ACTION_APP_LOCALE_SETTINGS).apply {
+                    data = Uri.fromParts("package", requireContext().packageName, null)
+                    startActivity(this)
+                }
+            } catch (e: Exception) {
+                try {
+                    Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                        data = Uri.fromParts("package", requireContext().packageName, null)
+                        startActivity(this)
+                    }
+                } catch (e: Exception) {
+                    println(e)
+                }
+            }
+        }
         private fun openDialogScientificModeSelector(context: Context) {
 
             val preferences = MyPreferences(context)
@@ -188,29 +211,6 @@ class SettingsActivity : AppCompatActivity() {
             }
             val dialog = builder.create()
             dialog.show()
-        }
-        private fun reloadActivity(context: Context) {
-            (context as Activity).finish()
-            ContextCompat.startActivity(context, context.intent, null)
-        }
-
-        @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-        fun launchChangeAppLanguageIntent() {
-            try {
-                Intent(Settings.ACTION_APP_LOCALE_SETTINGS).apply {
-                    data = Uri.fromParts("package", requireContext().packageName, null)
-                    startActivity(this)
-                }
-            } catch (e: Exception) {
-                try {
-                    Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                        data = Uri.fromParts("package", requireContext().packageName, null)
-                        startActivity(this)
-                    }
-                } catch (e: Exception) {
-                    println(e)
-                }
-            }
         }
     }
 }

--- a/app/src/main/java/com/darkempire78/opencalculator/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/activities/SettingsActivity.kt
@@ -17,6 +17,8 @@ import com.darkempire78.opencalculator.MyPreferences
 import com.darkempire78.opencalculator.R
 import com.darkempire78.opencalculator.Themes
 import com.darkempire78.opencalculator.calculator.parser.NumberingSystem
+import com.darkempire78.opencalculator.util.ScientificMode
+import com.darkempire78.opencalculator.util.ScientificModeTypes
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import java.util.Locale
 
@@ -98,6 +100,21 @@ class SettingsActivity : AppCompatActivity() {
                 openDialogNumberingSystemSelector(this.requireContext())
                 true
             }
+
+
+            // Numbering System button  settings_select_scientificMode_system
+            val scientificModeTypesSystemPreference =
+                findPreference<Preference>("darkempire78.opencalculator.SCIENTIFIC_MODE_ENABLED_BY_DEFAULT")
+
+            val storedType = MyPreferences(requireContext()).scientificMode
+           val scientificModeType = ScientificMode.getScientificModeType(storedType)
+            val typeDescription=ScientificMode.getScientificModeTypeDescription(requireContext(),scientificModeType)
+            scientificModeTypesSystemPreference?.summary = typeDescription
+            scientificModeTypesSystemPreference?.setOnPreferenceClickListener {
+                openDialogScientificModeSelector(this.requireContext())
+                true
+            }
+
         }
 
         private fun openDialogNumberingSystemSelector(context: Context) {
@@ -134,6 +151,45 @@ class SettingsActivity : AppCompatActivity() {
             dialog.show()
         }
 
+        private fun openDialogScientificModeSelector(context: Context) {
+
+            val preferences = MyPreferences(context)
+
+            val builder = MaterialAlertDialogBuilder(context)
+            builder.background = ContextCompat.getDrawable(context, R.drawable.rounded)
+
+            val scientificMode = hashMapOf(
+                0 to context.getString(R.string.settings_general_scientific_mode_deactivate_desc),
+                1 to context.getString(R.string.settings_general_scientific_mode_desc),
+                2 to context.getString(R.string.settings_general_scientific_mode_hide_desc)
+            )
+
+            val checkedItem = preferences.scientificMode
+
+            builder.setSingleChoiceItems(
+                scientificMode.values.toTypedArray(),
+                checkedItem
+            ) { dialog, which ->
+                when (which) {
+                    0 -> {
+                        preferences.scientificMode = 0
+                    }
+
+                    1 -> {
+                        preferences.scientificMode = 1
+                    }
+
+                    2-> {
+                        preferences.scientificMode = 2
+                    }
+
+                }
+                dialog.dismiss()
+                reloadActivity(requireContext())
+            }
+            val dialog = builder.create()
+            dialog.show()
+        }
         private fun reloadActivity(context: Context) {
             (context as Activity).finish()
             ContextCompat.startActivity(context, context.intent, null)

--- a/app/src/main/java/com/darkempire78/opencalculator/util/MyPreferenceMigrator.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/util/MyPreferenceMigrator.kt
@@ -1,0 +1,102 @@
+import android.content.SharedPreferences
+import com.darkempire78.opencalculator.util.ScientificModeTypes
+
+/**
+ * Handles migration of SharedPreferences values between different data types.
+ * Primarily used for converting boolean flags to enum ordinal representations.
+ */
+object MyPreferenceMigrator {
+
+
+    /**
+     * Migrates a boolean preference value to its corresponding enum ordinal representation.
+     *
+     * @param sharedPreferences The SharedPreferences instance containing the value to migrate
+     * @param key The preference key to migrate
+     * @return The migrated ordinal value according to these rules:
+     *         - true → ScientificModeTypes.ACTIVE.ordinal (1)
+     *         - false → ScientificModeTypes.NOT_ACTIVE.ordinal (0)
+     *         - Invalid/unknown types → ScientificModeTypes.OFF.ordinal (2)
+     * @throws IllegalArgumentException if sharedPreferences is null
+     */
+    fun migrateScientificMode(sharedPreferences: SharedPreferences, key: String): Int {
+
+        return when (val value = sharedPreferences.all[key]) {
+            // Boolean case - convert to corresponding ordinal
+            is Boolean -> {
+                val modeOrdinal = when {
+                    value -> ScientificModeTypes.ACTIVE.ordinal
+                    else -> ScientificModeTypes.NOT_ACTIVE.ordinal
+                }
+                saveMigratedValue(sharedPreferences, key, modeOrdinal)
+            }
+
+            // Already migrated case (stored as Int)
+            is Int -> {
+                if (value in ScientificModeTypes.entries.toTypedArray().indices) {
+                    value // Return existing valid ordinal
+                } else {
+                    resetToDefault(sharedPreferences, key)
+                }
+            }
+            // All other cases reset to OFF
+            else -> resetToDefault(sharedPreferences, key)
+        }
+    }
+
+    /**
+     * Safely saves a migrated value to SharedPreferences.
+     *
+     * @param sharedPreferences The SharedPreferences instance to modify
+     * @param key The preference key to update
+     * @param value The ordinal value to save
+     * @return The saved ordinal value
+     * @throws IllegalArgumentException if value is not a valid ordinal
+     */
+    private fun saveMigratedValue(
+        sharedPreferences: SharedPreferences,
+        key: String,
+        value: Int
+    ): Int {
+        require(value in ScientificModeTypes.entries.toTypedArray().indices) {
+            "Invalid ordinal value $value for ScientificModeTypes"
+        }
+
+        sharedPreferences.edit()
+            .remove(key) // Remove old value first
+            .putInt(key, value)
+            .apply()
+        return value
+    }
+
+    /**
+     * Resets a preference to the default OFF state.
+     *
+     * @param sharedPreferences The SharedPreferences instance to modify
+     * @param key The preference key to reset
+     * @return The default ordinal value (ScientificModeTypes.OFF.ordinal)
+     */
+    private fun resetToDefault(sharedPreferences: SharedPreferences, key: String): Int {
+        return saveMigratedValue(
+            sharedPreferences,
+            key,
+            ScientificModeTypes.OFF.ordinal
+        )
+    }
+
+    /**
+     * Helper function to safely retrieve the current scientific mode.
+     *
+     * @param sharedPreferences The SharedPreferences instance to read from
+     * @param key The preference key to read
+     * @return The current ScientificModeTypes enum value
+     */
+    fun getCurrentMode(sharedPreferences: SharedPreferences, key: String): ScientificModeTypes {
+        return try {
+            val ordinal = sharedPreferences.getInt(key, ScientificModeTypes.OFF.ordinal)
+            ScientificModeTypes.entries.getOrNull(ordinal) ?: ScientificModeTypes.OFF
+        } catch (e: Exception) {
+            ScientificModeTypes.OFF
+        }
+    }
+}

--- a/app/src/main/java/com/darkempire78/opencalculator/util/ScientificMode.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/util/ScientificMode.kt
@@ -1,0 +1,29 @@
+package com.darkempire78.opencalculator.util
+
+import android.content.Context
+
+object ScientificMode {
+    fun getScientificModeTypeDescription(
+        context: Context,
+        scientificModeTypes: ScientificModeTypes
+    ): String {
+        return when (scientificModeTypes) {
+            ScientificModeTypes.OFF -> context.getString(com.darkempire78.opencalculator.R.string.settings_general_scientific_mode_hide_desc)
+            ScientificModeTypes.NOT_ACTIVE -> context.getString(com.darkempire78.opencalculator.R.string.settings_general_scientific_mode_deactivate_desc)
+            ScientificModeTypes.ACTIVE -> context.getString(com.darkempire78.opencalculator.R.string.settings_general_scientific_mode_desc)
+        }
+    }
+
+    fun getScientificModeType(type:Int):ScientificModeTypes{
+        return when (type) {
+            ScientificModeTypes.NOT_ACTIVE.ordinal -> ScientificModeTypes.NOT_ACTIVE
+            ScientificModeTypes.ACTIVE.ordinal -> ScientificModeTypes.ACTIVE
+            else -> ScientificModeTypes.OFF
+        }
+    }
+}
+enum class ScientificModeTypes{
+    NOT_ACTIVE,
+    ACTIVE,
+    OFF
+}

--- a/app/src/main/java/com/darkempire78/opencalculator/util/ScientificMode.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/util/ScientificMode.kt
@@ -23,7 +23,7 @@ object ScientificMode {
     }
 }
 enum class ScientificModeTypes{
-    NOT_ACTIVE,
-    ACTIVE,
-    OFF
+    NOT_ACTIVE, //0
+    ACTIVE,//1
+    OFF //2
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -48,6 +48,27 @@
 
     </HorizontalScrollView>
 
+    <!-- <EditText
+        android:id="@+id/resultDisplay"
+        style="@style/RobotoFontCondensedMedium"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:scrollHorizontally="true"
+        android:clickable="false"
+        android:cursorVisible="false"
+        android:focusable="false"
+        android:singleLine="true"
+        android:background="?attr/foreground_color"
+        android:inputType="textNoSuggestions"
+        android:text=""
+        android:textColor="?attr/text_second_color"
+        android:layout_weight="1"
+        android:textAlignment="textEnd"
+        android:textSize="35sp"
+        android:paddingHorizontal="10dp"
+        android:paddingBottom="4dp"
+        app:layout_constraintBottom_toTopOf="@+id/guideline2"
+        app:layout_constraintTop_toTopOf="@+id/guideline1" /> -->
 
     <HorizontalScrollView
         android:id="@+id/resultDisplayHorizontalScrollView"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -48,27 +48,6 @@
 
     </HorizontalScrollView>
 
-    <!-- <EditText
-        android:id="@+id/resultDisplay"
-        style="@style/RobotoFontCondensedMedium"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:scrollHorizontally="true"
-        android:clickable="false"
-        android:cursorVisible="false"
-        android:focusable="false"
-        android:singleLine="true"
-        android:background="?attr/foreground_color"
-        android:inputType="textNoSuggestions"
-        android:text=""
-        android:textColor="?attr/text_second_color"
-        android:layout_weight="1"
-        android:textAlignment="textEnd"
-        android:textSize="35sp"
-        android:paddingHorizontal="10dp"
-        android:paddingBottom="4dp"
-        app:layout_constraintBottom_toTopOf="@+id/guideline2"
-        app:layout_constraintTop_toTopOf="@+id/guideline1" /> -->
 
     <HorizontalScrollView
         android:id="@+id/resultDisplayHorizontalScrollView"
@@ -137,6 +116,7 @@
                 app:layout_constraintTop_toTopOf="parent">
 
                 <TableRow
+                    android:id="@+id/scientistModeRow1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="1dp"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -23,6 +23,8 @@
     <string name="settings_general_radians_desc">استخدام الراديان بدلا من الدرجات</string>
     <string name="settings_general_scientific_mode">الوضع العلمي</string>
     <string name="settings_general_scientific_mode_desc">تفعيل الوضع العلمي تلقائيا</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">إلغاء تنشيط الوضع العلمي</string>
+    <string name="settings_general_scientific_mode_hide_desc">إخفاء الوضع العلمي</string>
     <string name="settings_general_split_parenthesis_button">فصل زر الاقواس ليصبح زرين</string>
     <string name="settings_general_split_parenthesis_button_desc">ازالة زر المسح \"AC\" ليتم فصل زر الاقواس الى زرين</string>
     <string name="settings_history_size">النتائج المحفوظة في السجل</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -31,6 +31,8 @@
     <string name="settings_general_theme">Тэма</string>
     <string name="menu_clear_history">Ачысціць гісторыю</string>
     <string name="settings_general_scientific_mode_desc">Выкарыстоўваць інжынерны рэжым па змаўчанні</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Дэактываваць навуковы рэжым</string>
+    <string name="settings_general_scientific_mode_hide_desc">Схаваць навуковы рэжым</string>
     <string name="settings_advanced_prevent_sleep_desc">Не дазваляйце тэлефону пераходзіць у рэжым сну, калі праграма працуе на пярэднім плане</string>
     <string name="settings_general_scientific_mode">Інжынерны рэжым</string>
     <string name="settings_general_vibration_desc">Выдаваць вібрацыю пры націску кнопкі</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -36,6 +36,8 @@
     <string name="settings_general_vibration">Vibracije</string>
     <string name="settings_general_radians_desc">Podrazumevano koristi radijane umjesto stupnjeva</string>
     <string name="settings_general_scientific_mode_desc">Podrazumevano aktiviraj napredni režim</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Deaktiviraj znanstveni način</string>
+    <string name="settings_general_scientific_mode_hide_desc">Skrij znanstveni način</string>
     <string name="settings_formatting_precision">Broj decimalnih mjesta</string>
     <string name="settings_general_language">Jezik</string>
     <string name="about_other_privacy_policy">Politika privatnosti</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -29,6 +29,8 @@
     <string name="settings_general_radians">Radians</string>
     <string name="settings_general_radians_desc">Usa radians en lloc de graus per defecte</string>
     <string name="settings_general_scientific_mode_desc">Activa el mode científic per defecte</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Desactiva el mode científic</string>
+    <string name="settings_general_scientific_mode_hide_desc">Amaga el mode científic</string>
     <string name="settings_formatting_scientific_notation">Número en notació científica</string>
     <string name="settings_formatting_scientific_notation_desc">Converteix tots els resultats en notació científica</string>
     <string name="settings_general_split_parenthesis_button">Divideix el botó dels parèntesis en dos botons</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -20,6 +20,8 @@
     <string name="settings_advanced_prevent_sleep">Udržovat zařízení vzhůru</string>
     <string name="settings_category_advanced">POKROČILÉ</string>
     <string name="settings_general_scientific_mode_desc">Používat vědecký režim jako výchozí</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Deaktivovat vědecký režim</string>
+    <string name="settings_general_scientific_mode_hide_desc">Skrýt vědecký režim</string>
     <string name="settings_general_radians">Radiány</string>
     <string name="settings_general_radians_desc">Používat radiány místo stupňů</string>
     <string name="about_category_help">POMOZTE NÁM</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -24,6 +24,8 @@
     <string name="settings_advanced_prevent_sleep">Bildschirm ausschalten verhindern</string>
     <string name="settings_category_advanced">ERWEITERT</string>
     <string name="settings_general_scientific_mode_desc">Wissenschaftlichen Modus standardmäßig aktivieren</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Wissenschaftlichen Modus deaktivieren</string>
+    <string name="settings_general_scientific_mode_hide_desc">Wissenschaftlichen Modus ausblenden</string>
     <string name="settings_general_scientific_mode">Wissenschaftlicher Modus</string>
     <string name="settings_general_radians">Radiant</string>
     <string name="settings_general_radians_desc">Radiant (RAD) statt Grad (DEG) standardmäßig verwenden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -36,6 +36,8 @@
     <string name="settings_formatting_precision">Cantidad de decimales</string>
     <string name="settings_history_size">Resultados guardados en el historial</string>
     <string name="settings_general_scientific_mode_desc">Activar el modo científico por defecto</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Desactivar el modo científico</string>
+    <string name="settings_general_scientific_mode_hide_desc">Ocultar modo científico</string>
     <string name="about_help_donate">Donar</string>
     <string name="about_help_rate">Valora esta aplicación</string>
     <string name="settings_general_language">Idioma</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -25,6 +25,8 @@
     <string name="settings_general_radians_desc">Vaikimisi kasuta kraadide asemel radiaane</string>
     <string name="settings_general_scientific_mode">Teadusarvutus</string>
     <string name="settings_general_scientific_mode_desc">Vaikimisi lülita sisse teadusarvutuse vaade</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Teadusrežiimi deaktiveerimine</string>
+    <string name="settings_general_scientific_mode_hide_desc">Peida teadusrežiim</string>
     <string name="settings_general_split_parenthesis_button_desc">Eemalda „AC“ nupp ja jaga ümarsulgude nupp kaheks nupuks</string>
     <string name="settings_general_add_modulo">Lisa mooduli nupp</string>
     <string name="settings_formatting_precision">Komakohtade arv</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -24,6 +24,8 @@
     <string name="settings_advanced_prevent_sleep">Empêcher le téléphone de se mettre en veille</string>
     <string name="settings_category_advanced">AVANCÉ</string>
     <string name="settings_general_scientific_mode_desc">Activer le mode scientifique par défaut</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Désactiver le mode scientifique</string>
+    <string name="settings_general_scientific_mode_hide_desc">Masquer le mode scientifique</string>
     <string name="settings_general_scientific_mode">Mode scientifique</string>
     <string name="settings_general_radians">Radians</string>
     <string name="settings_general_radians_desc">Utiliser les radians à la place des degrés par défaut</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -51,6 +51,8 @@
     <string name="settings_general_radians_desc">Bain úsáid as radians in ionad céimeanna de réir réamhshocraithe</string>
     <string name="settings_general_scientific_mode">Modh eolaíoch</string>
     <string name="settings_general_scientific_mode_desc">Gníomhachtaigh mód eolaíoch de réir réamhshocraithe</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Díghníomhachtaigh an mód eolaíoch</string>
+    <string name="settings_general_scientific_mode_hide_desc">Folaigh modh eolaíoch</string>
     <string name="settings_general_split_parenthesis_button">Roinn an cnaipe lúibíní ina dhá chnaipe</string>
     <string name="settings_general_split_parenthesis_button_desc">Bain an cnaipe \"AC\" chun an cnaipe lúibíní a roinnt ina dhá chnaipe</string>
     <string name="settings_general_add_modulo">Cuir cnaipe modulo leis</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -35,6 +35,8 @@
     <string name="value_too_large">मान बहुत बड़ा है</string>
     <string name="settings_general_vibration">कंपन</string>
     <string name="settings_general_scientific_mode_desc">तयशुदा रूप से वैज्ञानिक मोड सक्रिय करें</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">वैज्ञानिक मोड निष्क्रिय करें</string>
+    <string name="settings_general_scientific_mode_hide_desc">वैज्ञानिक मोड छिपाएँ</string>
     <string name="settings_general_split_parenthesis_button">कोष्ठक बटन को दो बटनों में विभाजित करें</string>
     <string name="settings_formatting_scientific_notation">वैज्ञानिक संकेतन में संख्या</string>
     <string name="settings_formatting_scientific_notation_desc">सभी परिणामों को वैज्ञानिक संकेतन में परिवर्तित करें</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -36,6 +36,8 @@
     <string name="settings_category_general">Opće</string>
     <string name="settings_advanced_prevent_sleep_desc">Spriječi isključivanje ekrana dok se aplikacija nalazi u prvom planu</string>
     <string name="settings_general_scientific_mode_desc">Standardno aktiviraj znanstveni način rada</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Deaktiviraj znanstveni način rada</string>
+    <string name="settings_general_scientific_mode_hide_desc">Sakrij znanstveni način rada</string>
     <string name="settings_general_radians_desc">Koristi radijane umjesto stupnjeva prema zadanim postavkama</string>
     <string name="about_other_version">Verzija</string>
     <string name="about_easter_egg">Hvala što koristite OpenCalc ❤️</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -24,6 +24,8 @@
     <string name="syntax_error">Szintaxishiba</string>
     <string name="theme_system">Rendszer</string>
     <string name="settings_general_scientific_mode_desc">Tudományos mód használata alapértelmezés szerint</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Tudományos mód kikapcsolása</string>
+    <string name="settings_general_scientific_mode_hide_desc">Tudományos mód elrejtése</string>
     <string name="about_easter_egg">Köszönjük, hogy az OpenCalc-ot használja ❤️</string>
     <string name="menu_about">Névjegy</string>
     <string name="infinity">Végtelen</string>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -21,6 +21,8 @@
     <string name="syntax_error">Error de syntaxe</string>
     <string name="theme_system">Systema</string>
     <string name="settings_general_scientific_mode_desc">Activar modo scientific per predefinition</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Desactivar el modo científico</string>
+    <string name="settings_general_scientific_mode_hide_desc">Ocultar modo científico</string>
     <string name="about_easter_egg">Gratias per usar OpenCalc ❤️</string>
     <string name="about_category_info">INFORMATION DEL APPLICATION</string>
     <string name="menu_about">A proposito de</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -22,6 +22,8 @@
     <string name="settings_general_language">Bahasa</string>
     <string name="settings_general_vibration">Vibrasi</string>
     <string name="settings_general_scientific_mode_desc">Secara bawaan, gunakan mode ilmiah</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">Nonaktifkan mode ilmiah</string>
+    <string name="settings_general_scientific_mode_hide_desc">Sembunyikan mode ilmiah</string>
     <string name="settings_category_general">UMUM</string>
     <string name="settings_general_add_modulo">Tambahkan tombol modulo</string>
     <string name="settings_general_vibration_desc">Bergetar ketika tombol ditekan</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,9 +96,9 @@
     <string name="settings_general_radians_desc">Use radians instead of degrees by default</string>
 
     <string name="settings_general_scientific_mode">Scientific mode</string>
-    <string name="settings_general_scientific_mode_desc">Activate scientific mode</string>
-    <string name="settings_general_scientific_mode_deactivate_desc">DeActivate scientific mode</string>
-    <string name="settings_general_scientific_mode_hide_desc">Hide scientific mode</string>
+        <string name="settings_general_scientific_mode_desc">Activate scientific mode</string>
+        <string name="settings_general_scientific_mode_deactivate_desc">DeActivate scientific mode</string>
+        <string name="settings_general_scientific_mode_hide_desc">Hide scientific mode</string>
 
     <string name="settings_general_split_parenthesis_button">Split the parentheses button into two buttons</string>
     <string name="settings_general_split_parenthesis_button_desc">Remove the \"AC\" button to split the parentheses button into two buttons</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,7 +96,9 @@
     <string name="settings_general_radians_desc">Use radians instead of degrees by default</string>
 
     <string name="settings_general_scientific_mode">Scientific mode</string>
-    <string name="settings_general_scientific_mode_desc">Activate scientific mode by default</string>
+    <string name="settings_general_scientific_mode_desc">Activate scientific mode</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">DeActivate scientific mode</string>
+    <string name="settings_general_scientific_mode_hide_desc">Hide scientific mode</string>
 
     <string name="settings_general_split_parenthesis_button">Split the parentheses button into two buttons</string>
     <string name="settings_general_split_parenthesis_button_desc">Remove the \"AC\" button to split the parentheses button into two buttons</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,4 @@
-<resources
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation"
-    >
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name_display">Calculator</string>
 
     <!-- Numbers -->
@@ -96,9 +93,9 @@
     <string name="settings_general_radians_desc">Use radians instead of degrees by default</string>
 
     <string name="settings_general_scientific_mode">Scientific mode</string>
-        <string name="settings_general_scientific_mode_desc">Activate scientific mode</string>
-        <string name="settings_general_scientific_mode_deactivate_desc">DeActivate scientific mode</string>
-        <string name="settings_general_scientific_mode_hide_desc">Hide scientific mode</string>
+    <string name="settings_general_scientific_mode_desc">Activate scientific mode</string>
+    <string name="settings_general_scientific_mode_deactivate_desc">DeActivate scientific mode</string>
+    <string name="settings_general_scientific_mode_hide_desc">Hide scientific mode</string>
 
     <string name="settings_general_split_parenthesis_button">Split the parentheses button into two buttons</string>
     <string name="settings_general_split_parenthesis_button_desc">Remove the \"AC\" button to split the parentheses button into two buttons</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -54,15 +54,15 @@
             app:defaultValue="false"
             app:widgetLayout="@drawable/material_switch" />
 
-        <SwitchPreferenceCompat
+        <Preference
+            android:id="@+id/settings_select_scientificMode_system"
             app:key="darkempire78.opencalculator.SCIENTIFIC_MODE_ENABLED_BY_DEFAULT"
+            app:selectable="true"
+            app:enabled="true"
             app:title="@string/settings_general_scientific_mode"
             app:summary="@string/settings_general_scientific_mode_desc"
-            app:useSimpleSummaryProvider="true"
-            app:icon="@drawable/science"
-            app:singleLineTitle="false"
-            app:defaultValue="false"
-            app:widgetLayout="@drawable/material_switch" />
+            app:icon="@drawable/science" />
+
 
         <SwitchPreferenceCompat
             app:key="darkempire78.opencalculator.SPLIT_PARENTHESIS_BUTTON"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.8.0"
+agp = "8.5.2"
 androidslidinguppanel = "4.6.1"
 appcompat = "1.7.0"
 constraintlayout = "2.1.4"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.2"
+agp = "8.8.0"
 androidslidinguppanel = "4.6.1"
 appcompat = "1.7.0"
 constraintlayout = "2.1.4"


### PR DESCRIPTION
Add "Hide Scientific Mode" Option
Problem Statement
"Users requested the ability to hide the scientific mode bar entirely since some never use it. Currently, the app only allows toggling between ACTIVE and NOT_ACTIVE states, but the UI elements remain visible."

🚀 Solution
✅ Introduced a third state (OFF) in ScientificModeTypes to represent hidden mode.
✅ Added a new string resource (settings_general_scientific_mode_hide_desc).
✅ Updated logic to:

Hide the scientific bar when OFF is selected.

Preserve existing ACTIVE/NOT_ACTIVE toggle functionality.

🔧 Technical Changes
1. Enum Update
kotlin
enum class ScientificModeTypes {
    NOT_ACTIVE,  // 👉 Deactivated but visible
    ACTIVE,      // 👉 Activated and visible
    HIDE          // 👉 Hidden entirely
}
📌 Notes
🔹 Fixes #572
🔹 Follows Android’s Settings UX best practices
🔹 Strings are clear and user-friendly

📸 Screenshots 

<div style="display: flex; gap: 10px; margin-bottom: 15px;">
  <img src="https://github.com/user-attachments/assets/68f92165-a443-4251-b401-b497dc4340fe" alt="Image 1" style="width: 49%; height: "100";"/>
  <img src="https://github.com/user-attachments/assets/32495aff-c18c-4727-84d2-b1ecde35038f" alt="Image 2" style="width: 49%; height: "100";"/>
</div>
<div style="display: flex; gap: 10px;">
  <img src="https://github.com/user-attachments/assets/2e073465-4b6c-4920-ab2c-dd72e978eb1b" alt="Image 3" style="width: 49%; height: "100";"/>
  <img src="https://github.com/user-attachments/assets/32b3f16e-f5c9-41df-816a-43020b0c8e24" alt="Image 4" style="width: 49%; height: "100";"/>
</div>
