### PR TITLE
Rewrote getPercentString() to loop and catch percentages, nested or n

### DIFF
--- a/app/src/test/java/com/darkempire78/opencalculator/ExpressionUnitTest.kt
+++ b/app/src/test/java/com/darkempire78/opencalculator/ExpressionUnitTest.kt
@@ -56,6 +56,28 @@ class ExpressionUnitTest {
 
         result = calculate("(50+2)+(1+2)%", false).toDouble()
         assertEquals(53.56, result, 0.0)
+
+        result = calculate("164+(265-20%)", isDegreeModeActivated = false).toDouble()
+        assertEquals(376.0, result, 0.0)
+
+        result = calculate("(265-20%)+164", isDegreeModeActivated = false).toDouble()
+        assertEquals(376.0, result, 0.0)
+
+        result = calculate("164+(265-20%)%", isDegreeModeActivated = false).toDouble()
+        assertEquals(511.68, result, 0.0)
+
+        result = calculate("(164+(265-20%)%)+345%", isDegreeModeActivated = false).toDouble()
+        assertEquals(2276.976, result, 0.0)
+
+        /*
+        Samsung Calculator has a result of 22.76976 here and Google Calculator yields 16.732.
+        OpenCalc yields 18.75176. 4Investigating the correct answer.
+         We typically would not do something so ambiguous. Are we adding percentages or adding a
+         a percentage of the previous number? An answer of 7.21 is also possible. How far down
+         this rabbit hole do we want to go? Everyday calculations should be correct now.
+         */
+        result = calculate("164%+(265-20%)%+345%", isDegreeModeActivated = false).toDouble()
+        assertEquals(18.75176, result, 0.0)
     }
 
     @Test


### PR DESCRIPTION
Rewrote getPercentString() to loop and catch percentages, nested or not. Also cleaned up extra whitespace and added whitespace for readability. Added tests for percentages. All pass at present.

This corrects issue #586 at present and should accommodate past issues as well.

