### PR TITLE
Further fixes for issue #588

### DIFF
--- a/app/src/main/java/com/darkempire78/opencalculator/calculator/parser/Expression.kt
+++ b/app/src/main/java/com/darkempire78/opencalculator/calculator/parser/Expression.kt
@@ -285,10 +285,15 @@ class Expression {
 
         val cleanCalculationLength = cleanCalculation.length
         var i = 0
-        while (i < cleanCalculationLength) {
+
+        /*
+        Changed while (i < cleanCalculationLength)
+        as we are modifying the string so length varies
+         */
+        while (i < cleanCalculation.length) {
             if (i < cleanCalculation.length - 1) {
                 if (parenthesisOpened > 0) {
-                    if (cleanCalculation[i+1] in "(*-/+^") {
+                    if (cleanCalculation[i+1] in "(*-/+^)") {
                         cleanCalculation = cleanCalculation.addCharAtIndex(')', i+1)
                         parenthesisOpened -= 1
                     }
@@ -300,6 +305,7 @@ class Expression {
             }
             i++
         }
+
         cleanCalculation = cleanCalculation.replace("√", "sqrt")
         return cleanCalculation
     }
@@ -329,11 +335,11 @@ class Expression {
                             if (cleanCalculation[j-1] in "*/+^" && parenthesisOpened == 0) {
                                 break
                             }
+                            if (cleanCalculation[j-1] == ')') parenthesisOpened += 1
                             // If the previous character isn't a parenthesis
                             if (cleanCalculation[j-1] != ')') {
                                 // Count open parentheses
-                                if (cleanCalculation[j] == ')') parenthesisOpened +=1
-                                else if (cleanCalculation[j-1] == '(') parenthesisOpened -= 1
+                                if (cleanCalculation[j-1] == '(') parenthesisOpened -= 1
 
                                 // If there are no open parentheses, add an F in front of the 1st parenthesis
                                 if (parenthesisOpened == 0) {

--- a/app/src/test/java/com/darkempire78/opencalculator/ExpressionUnitTest.kt
+++ b/app/src/test/java/com/darkempire78/opencalculator/ExpressionUnitTest.kt
@@ -276,6 +276,18 @@ class ExpressionUnitTest {
         assertEquals(5.816778116567456, result, 0.0)
     }
 
+    @Test
+    fun factorial_square_isCorrect() {
+        var result = calculate("(√16)!", false).toDouble()
+        assertEquals(24.0, result, 0.0)
+
+        result = calculate("(√16)!+(√16)!", false).toDouble()
+        assertEquals(48.0, result, 0.0)
+
+        result = calculate("(√16)!+(√16)!+(√16)!", false).toDouble()
+        assertEquals(72.0, result, 0.0)
+    }
+
     private fun calculate(input: String, isDegreeModeActivated : Boolean) = calculator.evaluate(expression.getCleanExpression(input, decimalSeparatorSymbol, groupingSeparatorSymbol), isDegreeModeActivated)
 
     companion object {


### PR DESCRIPTION
Fixed issue for (√16)! example. Added test for this as well as (√16)!+(√16)! to ensure proper parsing. This should resolve #588.